### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Created an Express server to provide a simulated activity feed.

### What changed?

The `graphite-demo/server.js` file was added. This file sets up an Express server running on port 3000. It includes a GET endpoint ('/feed') that responds with a hard-coded activity feed.

### How to test?

Start the server with `node server.js` and visit `http://localhost:3000/feed`. You should see the hard-coded activity feed in the response.

### Why make this change?

This change allows us to provide a simulated activity feed for our application.

---

