### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

This PR introduces a new server.js file in the graphite-demo directory, implementing a simple Express.js server with a `/search` endpoint.

### What changed?

The /search endpoint allows for searching through a list of hardcoded tasks based on a query parameter, with the results sorted alphabetically.

### How to test?

You can test this endpoint by running the server (`node server.js`) and making a GET request to `http://localhost:3000/search?query=<your-query>`.

### Why make this change?

This change provides foundational backend functionality for the Graphite-Demo application, enabling users to search through tasks.

---

